### PR TITLE
fix: modified period mapping implementation

### DIFF
--- a/services/ipfs/docker-compose.yaml
+++ b/services/ipfs/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.5"
 services:
   ipfs-service:
     container_name: ipfs-daemon
-    image: ipfs/go-ipfs:v0.10.0
+    image: ipfs/go-ipfs:v0.11.0
     ports:
       - '4001:4001'
       - '5001:5001'
@@ -12,7 +12,7 @@ services:
     volumes:
       - ./data:/data/ipfs
     entrypoint: ipfs
-    command: daemon --writable
+    command: daemon --writable --init
   ipfs-server:
     image: nginx:stable-alpine
     container_name: ipfs-server

--- a/subgraph/mapping.ts
+++ b/subgraph/mapping.ts
@@ -368,7 +368,7 @@ export function handlePeriodModified(event: PeriodModified): void {
   let periodRegistry = PeriodRegistry.bind(event.address);
   let index: BigInt;
   for (
-    index = period.amountOfPeriods;
+    index = BigInt.fromI32(period.amountOfPeriods);
     event.params.periodsAdded.gt(index);
     index = index.plus(BigInt.fromI32(1))
   ) {

--- a/subgraph/mapping.ts
+++ b/subgraph/mapping.ts
@@ -368,7 +368,7 @@ export function handlePeriodModified(event: PeriodModified): void {
   let periodRegistry = PeriodRegistry.bind(event.address);
   let index: BigInt;
   for (
-    index = BigInt.fromI32(period.amountOfPeriods);
+    index = BigInt.fromString(period.amountOfPeriods.toString());
     event.params.periodsAdded.gt(index);
     index = index.plus(BigInt.fromI32(1))
   ) {


### PR DESCRIPTION
This PR fixes a type error in the handlePeriodModified subgraph mapping.

```
ERRO Handler skipped due to execution failure, error: 
Mapping aborted at ~lib/@graphprotocol/graph-ts/index.ts, line 811, column 4, 
with message: Value is not a BigInt. 

wasm backtrace:     
0: 0x1f2e - <unknown>!~lib/@graphprotocol/graph-ts/index/Value#toBigInt         
1: 0x2de6 - <unknown>!../generated/schema/Period#get:amountOfPeriods            
2: 0x2e09 - <unknown>!../mapping/handlePeriodModified       
, handler: handlePeriodModified
```

⚠️ Issues most likely remain since the mapping has never been used before.