### PR TITLE
add ability to mock sli with external adapter from deploy script

### DIFF
--- a/scripts.config.ts
+++ b/scripts.config.ts
@@ -41,6 +41,8 @@ export const scripts: ScriptsConfiguration = {
         serviceURL: 'https://bdslaToken.network',
         serviceAddress: 'one1kf42rl6yg2avkjsu34ch2jn8yjs64ycn4n9wdj',
         serviceTicker: SENetworkNames[0],
+        useTestExternalAdapter: true,
+        sliMockingPlan: [98, 97, 95, 99, 91]
       },
     },
     // INDEX 1 | Should be HONORED
@@ -66,6 +68,8 @@ export const scripts: ScriptsConfiguration = {
         serviceURL: 'https://bdslaToken.network',
         serviceAddress: 'one1kf42rl6yg2avkjsu34ch2jn8yjs64ycn4n9wdj',
         serviceTicker: SENetworkNames[0],
+        useTestExternalAdapter: false,
+        sliMockingPlan:[],
       },
     },
     // INDEX 2 | Should be HONORED
@@ -91,6 +95,8 @@ export const scripts: ScriptsConfiguration = {
         serviceURL: 'https://bdslaToken.network',
         serviceAddress: 'one1kf42rl6yg2avkjsu34ch2jn8yjs64ycn4n9wdj',
         serviceTicker: SENetworkNames[0],
+        useTestExternalAdapter: false,
+        sliMockingPlan:[],
       },
     },
     // INDEX 3 | Should be BREACHED
@@ -116,6 +122,8 @@ export const scripts: ScriptsConfiguration = {
         serviceURL: 'https://bdslaToken.network',
         serviceAddress: 'one1kf42rl6yg2avkjsu34ch2jn8yjs64ycn4n9wdj',
         serviceTicker: SENetworkNames[0],
+        useTestExternalAdapter: false,
+        sliMockingPlan:[],
       },
     },
     // INDEX 4 | Should be HONORED
@@ -141,6 +149,8 @@ export const scripts: ScriptsConfiguration = {
         serviceURL: 'https://bdslaToken.network',
         serviceAddress: 'one1kf42rl6yg2avkjsu34ch2jn8yjs64ycn4n9wdj',
         serviceTicker: SENetworkNames[0],
+        useTestExternalAdapter: false,
+        sliMockingPlan:[],
       },
     },
     // INDEX 5 | Should be BREACHED
@@ -166,6 +176,8 @@ export const scripts: ScriptsConfiguration = {
         serviceURL: 'https://bdslaToken.network',
         serviceAddress: 'one1kf42rl6yg2avkjsu34ch2jn8yjs64ycn4n9wdj',
         serviceTicker: SENetworkNames[0],
+        useTestExternalAdapter: false,
+        sliMockingPlan:[],
       },
     },
     // INDEX 6 | Should be HONORED
@@ -191,6 +203,8 @@ export const scripts: ScriptsConfiguration = {
         serviceURL: 'https://bdslaToken.network',
         serviceAddress: 'one1kf42rl6yg2avkjsu34ch2jn8yjs64ycn4n9wdj',
         serviceTicker: SENetworkNames[0],
+        useTestExternalAdapter: false,
+        sliMockingPlan:[],
       },
     },
     // INDEX 7 | Should be BREACHED
@@ -216,6 +230,8 @@ export const scripts: ScriptsConfiguration = {
         serviceURL: 'https://bdslaToken.network',
         serviceAddress: 'one1kf42rl6yg2avkjsu34ch2jn8yjs64ycn4n9wdj',
         serviceTicker: SENetworkNames[0],
+        useTestExternalAdapter: false,
+        sliMockingPlan:[],
       },
     },
     // INDEX 8 | Should be HONORED
@@ -241,6 +257,8 @@ export const scripts: ScriptsConfiguration = {
         serviceURL: 'https://bdslaToken.network',
         serviceAddress: 'one1kf42rl6yg2avkjsu34ch2jn8yjs64ycn4n9wdj',
         serviceTicker: SENetworkNames[0],
+        useTestExternalAdapter: false,
+        sliMockingPlan:[],
       },
     },
     // INDEX 9 | Should be BREACHED
@@ -266,6 +284,8 @@ export const scripts: ScriptsConfiguration = {
         serviceURL: 'https://bdslaToken.network',
         serviceAddress: 'one1kf42rl6yg2avkjsu34ch2jn8yjs64ycn4n9wdj',
         serviceTicker: SENetworkNames[0],
+        useTestExternalAdapter: false,
+        sliMockingPlan:[],
       },
     },
     // INDEX 10 | Should be HONORED
@@ -291,6 +311,8 @@ export const scripts: ScriptsConfiguration = {
         serviceURL: 'https://bdslaToken.network',
         serviceAddress: 'one1kf42rl6yg2avkjsu34ch2jn8yjs64ycn4n9wdj',
         serviceTicker: SENetworkNames[0],
+        useTestExternalAdapter: false,
+        sliMockingPlan:[],
       },
     },
     // INDEX 11 | Should be BREACHED
@@ -316,6 +338,8 @@ export const scripts: ScriptsConfiguration = {
         serviceURL: 'https://bdslaToken.network',
         serviceAddress: 'one1kf42rl6yg2avkjsu34ch2jn8yjs64ycn4n9wdj',
         serviceTicker: SENetworkNames[0],
+        useTestExternalAdapter: false,
+        sliMockingPlan:[],
       },
     },
     // INDEX 12
@@ -341,6 +365,8 @@ export const scripts: ScriptsConfiguration = {
         serviceURL: 'https://www.federalreserve.gov/',
         serviceAddress: '0x0000000000000000000000000000000000000000',
         serviceTicker: 'CPI',
+        useTestExternalAdapter: false,
+        sliMockingPlan:[],
       },
     },
     // INDEX 13
@@ -366,6 +392,8 @@ export const scripts: ScriptsConfiguration = {
         serviceURL: 'https://www.federalreserve.gov/',
         serviceAddress: '0x0000000000000000000000000000000000000000',
         serviceTicker: 'CPI',
+        useTestExternalAdapter: false,
+        sliMockingPlan:[],
       },
     },
     // INDEX 14
@@ -391,6 +419,8 @@ export const scripts: ScriptsConfiguration = {
         serviceURL: 'https://www.federalreserve.gov/',
         serviceAddress: '0x0000000000000000000000000000000000000000',
         serviceTicker: 'CPI',
+        useTestExternalAdapter: false,
+        sliMockingPlan:[],
       },
     },
     // INDEX 15
@@ -416,6 +446,8 @@ export const scripts: ScriptsConfiguration = {
         serviceURL: 'https://www.federalreserve.gov/',
         serviceAddress: '0x0000000000000000000000000000000000000000',
         serviceTicker: 'CPI',
+        useTestExternalAdapter: false,
+        sliMockingPlan:[],
       },
     },
     // INDEX 16
@@ -441,6 +473,8 @@ export const scripts: ScriptsConfiguration = {
         serviceURL: 'https://www.federalreserve.gov/',
         serviceAddress: '0x0000000000000000000000000000000000000000',
         serviceTicker: 'CPI',
+        useTestExternalAdapter: false,
+        sliMockingPlan:[],
       },
     }
   ],

--- a/services/external-adapter/index.ts
+++ b/services/external-adapter/index.ts
@@ -4,6 +4,7 @@ const axios = require('axios');
 const Web3 = require('web3');
 const { SLAABI, MessengerABI } = require('./abis');
 let web3Uri;
+let nextPeriod;
 
 type SLAData = {
   serviceName: string;
@@ -29,6 +30,7 @@ async function getSLAData(address): Promise<SLAData> {
   const ipfsCID = await slaContract.methods.ipfsHash().call();
   console.log(`SLA IPFS url: ${process.env.DEVELOP_IPFS_URI}/ipfs/${ipfsCID}`);
   const periodType = await slaContract.methods.periodType().call();
+  nextPeriod = await slaContract.methods.nextVerifiablePeriod().call();
   const messengerAddress = await slaContract.methods.messengerAddress().call();
   const { data } = await axios.get(
     `${process.env.IPFS_GATEWAY_URI}/ipfs/${ipfsCID}`
@@ -46,10 +48,20 @@ async function getSLI(requestData: RequestData) {
     slaData.messengerAddress
   );
   const precision = await messenger.methods.messengerPrecision().call();
-  // Just a random SLI, multiplied by 100 to get percentage
-  const sli = Math.random() * 100;
-  // times messenger precision to calculate on chain
-  return Math.floor(sli * precision);
+  if ((slaData.useTestExternalAdapter) &&
+    (slaData.sliMockingPlan !== undefined)){
+      console.log('Using pre specified mock sli');
+      const periodId = nextPeriod
+      const sli = slaData['sliMockingPlan'][nextPeriod]
+      console.log('mocking sli value ' + sli + ' for period ' + periodId)
+      return sli
+  }
+  else {
+    // Just a random SLI, multiplied by 100 to get percentage
+    const sli = Math.random() * 100;
+    // times messenger precision to calculate on chain
+    return Math.floor(sli * precision);
+  }
 }
 
 const app = express();

--- a/types.ts
+++ b/types.ts
@@ -103,6 +103,8 @@ export type DeploySLAConfiguration = {
     serviceURL: string;
     serviceAddress: string;
     serviceTicker: string;
+    useTestExternalAdapter: boolean;
+    sliMockingPlan: Array<number>;
   };
   sloValue: number;
   sloType: SLO_TYPE;


### PR DESCRIPTION
Added ability to mock sli result set in deploy script. Now developer can set a mocked sli plan to perform tests.
Exemple:
sliMockingPlan: [98, 97, 95, 99, 91]
For the moment "sliMockingPlan" informations are in "serviceMetadata" object. But I'm considering the option to add a new property in contract details for sli mocking configuration.
Task DSLA-91, Required for DSLA-64.