### PR TITLE
Fix/enhance parametric staking it

### DIFF
--- a/scripts.config.ts
+++ b/scripts.config.ts
@@ -648,7 +648,7 @@ export const scripts: ScriptsConfiguration = {
       },
     },*/
     // INDEX 22, Contract for IT staking parametric tests: Breached case, max compensation of 25%
-    // Cases: price stable, price rise,  price huge rise (capped reward)
+    // Cases: price stable, price rise,  price huge rise (capped reward) USED CONTRACT CONF
     {
       sloValue: 1,
       sloType: SLO_TYPE.SmallerThan,
@@ -658,7 +658,7 @@ export const scripts: ScriptsConfiguration = {
       initialPeriodId: 0,
       finalPeriodId: 2,
       severity: [0, 100000, 250000], // [0%, 100%, 250%] (1000 == 1%) [price stable or down, up 100%, up 250%]
-      penalty: [100, 10000, 25000], // [1%, 10%, 25%]
+      penalty: [100, 1000, 2500], // [1%, 10%, 25%]
       initialTokenSupply: '0',
       initialTokenSupplyDivisor: 100,
       deployerStakeTimes: 100,

--- a/scripts.config.ts
+++ b/scripts.config.ts
@@ -658,7 +658,7 @@ export const scripts: ScriptsConfiguration = {
       initialPeriodId: 0,
       finalPeriodId: 2,
       severity: [0, 100000, 250000], // [0%, 100%, 250%] (1000 == 1%) [price stable or down, up 100%, up 250%]
-      penalty: [100, 1000, 2500], // [1%, 10%, 25%]
+      penalty: [100, 10000, 25000], // [1%, 10%, 25%]
       initialTokenSupply: '0',
       initialTokenSupplyDivisor: 100,
       deployerStakeTimes: 100,
@@ -674,7 +674,7 @@ export const scripts: ScriptsConfiguration = {
         serviceAddress: '',
         serviceTicker: 'PH',
         serviceUseTestExternalAdapter: true,
-        serviceSliMockingPlan: [11730, 100000, 250000],
+        serviceSliMockingPlan: [1000, 100001, 250001],
         ...StakingParametricMessengerSpec,
       },
     },

--- a/scripts.config.ts
+++ b/scripts.config.ts
@@ -25,7 +25,7 @@ const StakingParametricMessengerSpec = JSON.parse(
 export const scripts: ScriptsConfiguration = {
   deploy_sla: [
     // INDEX 0 | Should be BREACHED
-    {
+    /*{
       sloValue: 100, // Breached as SL0 > SLi is false
       sloType: SLO_TYPE.GreaterThan,
       whitelisted: false,
@@ -646,7 +646,7 @@ export const scripts: ScriptsConfiguration = {
         serviceSliMockingPlan: [1000, 100000, 250000],
         ...StakingParametricMessengerSpec,
       },
-    },
+    },*/
     // INDEX 22, Contract for IT staking parametric tests: Breached case, max compensation of 25%
     // Cases: price stable, price rise,  price huge rise (capped reward)
     {
@@ -674,14 +674,14 @@ export const scripts: ScriptsConfiguration = {
         serviceAddress: '',
         serviceTicker: 'PH',
         serviceUseTestExternalAdapter: true,
-        serviceSliMockingPlan: [1000, 100000, 250000],
+        serviceSliMockingPlan: [11730, 100000, 250000],
         ...StakingParametricMessengerSpec,
       },
     },
     // INDEX 23, Contract for IT staking parametric tests: Breached case, max compensation of 25%
     // Cases: price stable, price rise,  price huge rise (capped reward)
     {
-      sloValue: 1,
+      sloValue: 102,
       sloType: SLO_TYPE.SmallerThan,
       whitelisted: false,
       periodType: PERIOD_TYPE.HOURLY,
@@ -710,7 +710,7 @@ export const scripts: ScriptsConfiguration = {
     },
     // INDEX 24, Contract for mainnet deployment of DSLA Parametric Staking
     {
-      sloValue: 1,
+      sloValue: 103,
       sloType: SLO_TYPE.SmallerThan,
       whitelisted: false,
       periodType: PERIOD_TYPE.MONTHLY,

--- a/scripts.config.ts
+++ b/scripts.config.ts
@@ -25,7 +25,7 @@ const StakingParametricMessengerSpec = JSON.parse(
 export const scripts: ScriptsConfiguration = {
   deploy_sla: [
     // INDEX 0 | Should be BREACHED
-    /*{
+    {
       sloValue: 100, // Breached as SL0 > SLi is false
       sloType: SLO_TYPE.GreaterThan,
       whitelisted: false,
@@ -646,7 +646,7 @@ export const scripts: ScriptsConfiguration = {
         serviceSliMockingPlan: [1000, 100000, 250000],
         ...StakingParametricMessengerSpec,
       },
-    },*/
+    },
     // INDEX 22, Contract for IT staking parametric tests: Breached case, max compensation of 25%
     // Cases: price stable, price rise,  price huge rise (capped reward) USED CONTRACT CONF
     {

--- a/test/integration/staking/Parametric.test.ts
+++ b/test/integration/staking/Parametric.test.ts
@@ -403,8 +403,8 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
         const deviationAndDetails = getDeviationAndDetails(severities, penalties, sli)
 
         //this is to fix
-        const presumablyAppliedSeverity = scripts.deploy_sla[sla_script_index].severity[periodId_p1]
-        const presumablyAppliedPenalty = scripts.deploy_sla[sla_script_index].penalty[periodId_p1]
+        const presumablyAppliedSeverity = deviationAndDetails[2].severity;
+        const presumablyAppliedPenalty = deviationAndDetails[2].penalty;
 
         // Presumably applied severity
         // Presumably applied penalty

--- a/test/integration/staking/Parametric.test.ts
+++ b/test/integration/staking/Parametric.test.ts
@@ -108,6 +108,10 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
     let P1UserPool = "101000";
     let P1TotalStake = "400000";
     let P1NumberOfStakers = 6;
+
+    let P1expectedUserPoolChangePct10f4 = "10000"
+    let P2expectedUserPoolChangePct10f4 = "100000"
+    let P3expectedUserPoolChangePct10f4 = "250000"
   
     // Stacking constants P2
     // PROVIDERS BALANCE
@@ -155,6 +159,14 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
 
     let P2P3ProviderPoolDelta: BigNumber = BigNumber.from("0");
     let P2P3UsersPoolDelta: BigNumber = BigNumber.from("0");
+
+    let providerPoolPctChangeP0toP1mulByPrescision: BigNumber = BigNumber.from("0");
+    let providerPoolPctChangeP1toP2mulByPrescision: BigNumber = BigNumber.from("0");
+    let providerPoolPctChangeP2toP3mulByPrescision: BigNumber = BigNumber.from("0");
+
+    let userPoolPctChangeP0toP1mulByPrescision: BigNumber = BigNumber.from("0");
+    let userPoolPctChangeP1toP2mulByPrescision: BigNumber = BigNumber.from("0");
+    let userPoolPctChangeP2toP3mulByPrescision: BigNumber = BigNumber.from("0");
   
     let currentP1ProviderPool: BigNumber = BigNumber.from("0");
     let currentP1UsersPool: BigNumber = BigNumber.from("0");
@@ -391,11 +403,11 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
         const percentPrescision = 10**4
 
         const P0P1UsersPoolDeltaBy100andPrescision = P0P1UsersPoolDelta.mul(100).mul(percentPrescision);
-        const userPoolPctChangeP0toP1mulByPrescision = P0P1UsersPoolDeltaBy100andPrescision.div(P0UsersPool);
+        userPoolPctChangeP0toP1mulByPrescision = P0P1UsersPoolDeltaBy100andPrescision.div(P0UsersPool);
         const userPoolPctChangeP0toP1 = userPoolPctChangeP0toP1mulByPrescision.div(percentPrescision);
 
         const P0P1PrividerPoolDeltaBy100andPrescision = P0P1ProviderPoolDelta.mul(100).mul(percentPrescision);
-        const providerPoolPctChangeP0toP1mulByPrescision = P0P1PrividerPoolDeltaBy100andPrescision.div(P0ProviderPool);
+        providerPoolPctChangeP0toP1mulByPrescision = P0P1PrividerPoolDeltaBy100andPrescision.div(P0ProviderPool);
         const providerPoolPctChangeP0toP1 = providerPoolPctChangeP0toP1mulByPrescision.div(percentPrescision);
 
         const slaContractSloValue = slaStaticDetailsP1.sloValue
@@ -451,6 +463,9 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
       it('Total User Pool should be equal to P1 expected value', function () {
         expect(currentP1UsersPool.toString()).equals(toWei(P1UserPool.toString()));
       });
+      it('User Pool change percent (10 **4) from P0 to P1 should be expected value', function () {
+        expect(userPoolPctChangeP0toP1mulByPrescision.toString()).equals(P1expectedUserPoolChangePct10f4.toString());
+      });
       it('Total Liquidity Pool should be equal to P1 expected value', function () {
         expect(currentP1TotalStake.toString()).equals(toWei(P1TotalStake.toString()));
       });
@@ -504,11 +519,11 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
         const percentPrescision = 10**4
 
         const P1P2UsersPoolDeltaBy100andPrescision = P1P2UsersPoolDelta.mul(100).mul(percentPrescision);
-        const userPoolPctChangeP1toP2mulByPrescision = P1P2UsersPoolDeltaBy100andPrescision.div(currentP1UsersPool);
+        userPoolPctChangeP1toP2mulByPrescision = P1P2UsersPoolDeltaBy100andPrescision.div(currentP1UsersPool);
         const userPoolPctChangeP1toP2 = userPoolPctChangeP1toP2mulByPrescision.div(percentPrescision);
 
         const P1P2ProviderPoolDeltaBy100andPrescision = P1P2ProviderPoolDelta.mul(100).mul(percentPrescision);
-        const providerPoolPctChangeP1toP2mulByPrescision = P1P2ProviderPoolDeltaBy100andPrescision.div(currentP1ProviderPool);
+        providerPoolPctChangeP1toP2mulByPrescision = P1P2ProviderPoolDeltaBy100andPrescision.div(currentP1ProviderPool);
         const providerPoolPctChangeP1toP2 = providerPoolPctChangeP1toP2mulByPrescision.div(percentPrescision);
 
         const severities = scripts.deploy_sla[sla_script_index].severity
@@ -561,6 +576,9 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
       });
       it('Total User Pool should be equal to P2 expected value', function () {
         expect(currentP2UsersPool.toString()).equals(toWei(P2UserPool.toString()));
+      });
+      it('User Pool change percent (10 **4) from P0 to P1 should be expected value', function () {
+        expect(userPoolPctChangeP1toP2mulByPrescision.toString()).equals(P2expectedUserPoolChangePct10f4.toString());
       });
       it('Total Liquidity Pool should be equal to P2 expected value', function () {
         expect(currentP2TotalStake.toString()).equals(toWei(P2TotalStake.toString()));
@@ -616,11 +634,11 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
         const percentPrescision = 10**4
 
         const P2P3UsersPoolDeltaBy100andPrescision = P2P3UsersPoolDelta.mul(100).mul(percentPrescision);
-        const userPoolPctChangeP2toP3mulByPrescision = P2P3UsersPoolDeltaBy100andPrescision.div(currentP2UsersPool);
+        userPoolPctChangeP2toP3mulByPrescision = P2P3UsersPoolDeltaBy100andPrescision.div(currentP2UsersPool);
         const userPoolPctChangeP2toP3 = userPoolPctChangeP2toP3mulByPrescision.div(percentPrescision);
 
         const P2P3ProviderPoolDeltaBy100andPrescision = P2P3ProviderPoolDelta.mul(100).mul(percentPrescision);
-        const providerPoolPctChangeP2toP3mulByPrescision = P2P3ProviderPoolDeltaBy100andPrescision.div(currentP2ProviderPool);
+        providerPoolPctChangeP2toP3mulByPrescision = P2P3ProviderPoolDeltaBy100andPrescision.div(currentP2ProviderPool);
         const providerPoolPctChangeP2toP3 = providerPoolPctChangeP2toP3mulByPrescision.div(percentPrescision);
 
         const severities = scripts.deploy_sla[sla_script_index].severity
@@ -674,6 +692,9 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
       });
       it('Total User Pool should be equal to P3 expected value', function () {
         expect(currentP3UsersPool.toString()).equals(toWei(P3UserPool.toString()));
+      });
+      it('User Pool change percent (10 **4) from P2 to P3 should be expected value', function () {
+        expect(userPoolPctChangeP2toP3mulByPrescision.toString()).equals(P3expectedUserPoolChangePct10f4.toString());
       });
       it('Total Liquidity Pool should be equal to P3 expected value', function () {
         expect(currentP3TotalStake.toString()).equals(toWei(P3TotalStake.toString()));

--- a/test/integration/staking/Parametric.test.ts
+++ b/test/integration/staking/Parametric.test.ts
@@ -80,7 +80,7 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
     const sla_script_index = 0
     // Stacking constants INITIAL
     // PROVIDERS BALANCE
-    let initialStakeBalanceProvider1 = "900000"; //100000
+    let initialStakeBalanceProvider1 = "100000"; //100000
     let initialStakeBalanceProvider2 = "100000";
     let initialStakeBalanceProvider3 = "100000";
   
@@ -91,7 +91,7 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
   
     let initialProviderPool = "1100000"; //300000
     let initialUserPool = "100000";
-    let initialTotalStake = "1200000"; //400000
+    let initialTotalStake = "400000"; //400000
     let initialNumberOfStakers = 6;
   
     // Stacking constants P1
@@ -455,7 +455,6 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
         expect(currentP1TotalStake.toString()).equals(toWei(P1TotalStake.toString()));
       });
     });
-
   });
 
 
@@ -505,7 +504,7 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
         const percentPrescision = 10**4
 
         const P1P2UsersPoolDeltaBy100andPrescision = P1P2UsersPoolDelta.mul(100).mul(percentPrescision);
-        const userPoolPctChangeP1toP2mulByPrescision = P1P2UsersPoolDeltaBy100andPrescision.div(currentP2UsersPool);
+        const userPoolPctChangeP1toP2mulByPrescision = P1P2UsersPoolDeltaBy100andPrescision.div(currentP1UsersPool);
         const userPoolPctChangeP1toP2 = userPoolPctChangeP1toP2mulByPrescision.div(percentPrescision);
 
         const P1P2ProviderPoolDeltaBy100andPrescision = P1P2ProviderPoolDelta.mul(100).mul(percentPrescision);
@@ -617,7 +616,7 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
         const percentPrescision = 10**4
 
         const P2P3UsersPoolDeltaBy100andPrescision = P2P3UsersPoolDelta.mul(100).mul(percentPrescision);
-        const userPoolPctChangeP2toP3mulByPrescision = P2P3UsersPoolDeltaBy100andPrescision.div(currentP3UsersPool);
+        const userPoolPctChangeP2toP3mulByPrescision = P2P3UsersPoolDeltaBy100andPrescision.div(currentP2UsersPool);
         const userPoolPctChangeP2toP3 = userPoolPctChangeP2toP3mulByPrescision.div(percentPrescision);
 
         const P2P3ProviderPoolDeltaBy100andPrescision = P2P3ProviderPoolDelta.mul(100).mul(percentPrescision);

--- a/test/integration/staking/Parametric.test.ts
+++ b/test/integration/staking/Parametric.test.ts
@@ -77,10 +77,10 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
 
 
     // get the contract INDEX XX, Contract for IT staking test
-    const sla_script_index = 0
+    const sla_script_index = 22;
     // Stacking constants INITIAL
     // PROVIDERS BALANCE
-    let initialStakeBalanceProvider1 = "100000"; //100000
+    let initialStakeBalanceProvider1 = "100000";
     let initialStakeBalanceProvider2 = "100000";
     let initialStakeBalanceProvider3 = "100000";
   
@@ -89,9 +89,9 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
     let initialStakeBalanceUser2 = "40000";
     let initialStakeBalanceUser3 = "50000";
   
-    let initialProviderPool = "1100000"; //300000
+    let initialProviderPool = "300000";
     let initialUserPool = "100000";
-    let initialTotalStake = "400000"; //400000
+    let initialTotalStake = "400000";
     let initialNumberOfStakers = 6;
   
     // Stacking constants P1

--- a/test/integration/staking/Parametric.test.ts
+++ b/test/integration/staking/Parametric.test.ts
@@ -80,7 +80,7 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
     const sla_script_index = 0
     // Stacking constants INITIAL
     // PROVIDERS BALANCE
-    let initialStakeBalanceProvider1 = "100000";
+    let initialStakeBalanceProvider1 = "900000"; //100000
     let initialStakeBalanceProvider2 = "100000";
     let initialStakeBalanceProvider3 = "100000";
   
@@ -89,9 +89,9 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
     let initialStakeBalanceUser2 = "40000";
     let initialStakeBalanceUser3 = "50000";
   
-    let initialProviderPool = "300000";
+    let initialProviderPool = "1100000"; //300000
     let initialUserPool = "100000";
-    let initialTotalStake = "400000";
+    let initialTotalStake = "1200000"; //400000
     let initialNumberOfStakers = 6;
   
     // Stacking constants P1
@@ -357,12 +357,6 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
           PERIOD_TYPE.MONTHLY, periodId_p1
         );
 
-        consola.info('Preparing to get balance before P1 request SLI for user 2:', user_2_account.address);
-        const duTokenUser2BalanceBeforeP1 = await duToken.balanceOf(user_2_account.address);
-        consola.info('Preparing to get balance before P1 request SLI for user 3:', user_3_account.address);
-        const duTokenUser3BalanceBeforeP1 = await duToken.balanceOf(user_3_account.address);
-
-
         console.log("Period starts and ends", periodStartEnd.start.toNumber(), periodStartEnd.end.toNumber())
         await evm_increaseTime(periodStartEnd.end.toNumber());
         await expect(slaRegistry.requestSLI(
@@ -511,11 +505,11 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
         const percentPrescision = 10**4
 
         const P1P2UsersPoolDeltaBy100andPrescision = P1P2UsersPoolDelta.mul(100).mul(percentPrescision);
-        const userPoolPctChangeP1toP2mulByPrescision = P1P2UsersPoolDeltaBy100andPrescision.div(currentP2ProviderPool);
+        const userPoolPctChangeP1toP2mulByPrescision = P1P2UsersPoolDeltaBy100andPrescision.div(currentP2UsersPool);
         const userPoolPctChangeP1toP2 = userPoolPctChangeP1toP2mulByPrescision.div(percentPrescision);
 
-        const P1P2PrividerPoolDeltaBy100andPrescision = P1P2ProviderPoolDelta.mul(100).mul(percentPrescision);
-        const providerPoolPctChangeP1toP2mulByPrescision = P1P2PrividerPoolDeltaBy100andPrescision.div(currentP1ProviderPool);
+        const P1P2ProviderPoolDeltaBy100andPrescision = P1P2ProviderPoolDelta.mul(100).mul(percentPrescision);
+        const providerPoolPctChangeP1toP2mulByPrescision = P1P2ProviderPoolDeltaBy100andPrescision.div(currentP1ProviderPool);
         const providerPoolPctChangeP1toP2 = providerPoolPctChangeP1toP2mulByPrescision.div(percentPrescision);
 
         const severities = scripts.deploy_sla[sla_script_index].severity
@@ -550,8 +544,8 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
         console.log("Provider Pool PctChange P2: ", providerPoolPctChangeP1toP2.toString(), "%")
         
         console.log("----")
-        console.log("User Pool balance P1: ", currentP1ProviderPool.toString())
-        console.log("User Pool balance P2: ", currentP1UsersPool.toString())
+        console.log("User Pool balance P1: ", currentP1UsersPool.toString())
+        console.log("User Pool balance P2: ", currentP2UsersPool.toString())
         console.log("User Delta P1 to P2: ", P1P2UsersPoolDelta.toString())
         console.log("User Pool PctChange P2  10 **4: ", userPoolPctChangeP1toP2mulByPrescision.toString())
         console.log("User Pool PctChange P2: ", userPoolPctChangeP1toP2.toString(), "%")
@@ -623,11 +617,11 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
         const percentPrescision = 10**4
 
         const P2P3UsersPoolDeltaBy100andPrescision = P2P3UsersPoolDelta.mul(100).mul(percentPrescision);
-        const userPoolPctChangeP2toP3mulByPrescision = P2P3UsersPoolDeltaBy100andPrescision.div(currentP3ProviderPool);
+        const userPoolPctChangeP2toP3mulByPrescision = P2P3UsersPoolDeltaBy100andPrescision.div(currentP3UsersPool);
         const userPoolPctChangeP2toP3 = userPoolPctChangeP2toP3mulByPrescision.div(percentPrescision);
 
-        const P2P3PrividerPoolDeltaBy100andPrescision = P2P3ProviderPoolDelta.mul(100).mul(percentPrescision);
-        const providerPoolPctChangeP2toP3mulByPrescision = P2P3PrividerPoolDeltaBy100andPrescision.div(currentP2ProviderPool);
+        const P2P3ProviderPoolDeltaBy100andPrescision = P2P3ProviderPoolDelta.mul(100).mul(percentPrescision);
+        const providerPoolPctChangeP2toP3mulByPrescision = P2P3ProviderPoolDeltaBy100andPrescision.div(currentP2ProviderPool);
         const providerPoolPctChangeP2toP3 = providerPoolPctChangeP2toP3mulByPrescision.div(percentPrescision);
 
         const severities = scripts.deploy_sla[sla_script_index].severity
@@ -670,7 +664,6 @@ describe('DSLA Protocol Parametric Staking Simulation - v2.1.0', () => {
         console.log("----")
         
         console.log("--------------------------------------------------------------")
-
 
 
       });


### PR DESCRIPTION
The goal of this PR is to extend the scope of parametric staking IT and enhance the logs in order to have a better result interpretation.
Bellow tests / logs added:

- Presumably applied severity
- Presumably applied penalty
- Display gain wallet gain percentage by user
- Display gain wallet percentage by provider
- Validate gain wallet gain percentage by user
- Validate Sample User Balance should be equal to Initial stake value
- Validate Sample Provider Balance should be equal to Initial stake value